### PR TITLE
Port to Azure AKS

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -18,4 +18,3 @@ spec:
   type: ClusterIP
   selector:
     app: bitwarden
-    component: bitwarden


### PR DESCRIPTION
I was able to deploy this on Azure AKS 1.9 by removing the component selector from the service. With the original configuration the ingress controller and the bitwarden service cannot connect.